### PR TITLE
closes 11 - fix dependent destroys

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::UsersController < ApplicationController
   def index
     @users = User.all#.map {|user| user.format_json}
     # deciding whether or not to use the serializer for data loading
-    users = UserSerializer.new(@users).serialized_json
+    users = UserSerializer.new(@users, { is_collection: true }).serialized_json
     render json: users
   end
 

--- a/app/models/completion.rb
+++ b/app/models/completion.rb
@@ -6,13 +6,19 @@ class Completion < ApplicationRecord
   belongs_to :league_pack
 
   def format_json
-    { id: self.id,
+    {
+      id: self.id,
       user_id: self.user_id,
       team_id: self.team_id,
       workout_pack_id: self.workout_pack_id,
       completed: self.completed,
-      league_pack_id: self.league_pack_id
+      league_pack_id: self.league_pack_id,
+      points: self.points_scored
     }
+  end
+
+  def points_scored
+    self.workout_pack.points
   end
 
 

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,5 +1,5 @@
 class Exercise < ApplicationRecord
-  has_many :workout_exercises
+  has_many :workout_exercises, dependent: :destroy
   has_many :workouts, through: :workout_exercises
 
 end

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -1,5 +1,5 @@
 class League < ApplicationRecord
-  has_many :teams
-  has_many :league_packs
+  has_many :teams, dependent: :destroy
+  has_many :league_packs, dependent: :destroy
   has_many :packs, through: :league_packs
 end

--- a/app/models/pack.rb
+++ b/app/models/pack.rb
@@ -1,6 +1,6 @@
 class Pack < ApplicationRecord
-  has_many :workout_packs
+  has_many :workout_packs, dependent: :destroy
   has_many :workouts, through: :workout_packs
-  has_many :league_packs
+  has_many :league_packs, dependent: :destroy
   has_many :leagues, through: :league_packs
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,6 @@
 class Team < ApplicationRecord
-  has_many :user_teams
+  has_many :user_teams, dependent: :destroy
   has_many :users, through: :user_teams
-  belongs_to :league, dependent: :destroy
+  belongs_to :league#, dependent: :destroy
   has_many :completions
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,4 +3,14 @@ class Team < ApplicationRecord
   has_many :users, through: :user_teams
   belongs_to :league#, dependent: :destroy
   has_many :completions
+
+  def format_json
+    {
+      id: self.id,
+      league_id: self.league_id,
+      name: self.name,
+      motto: self.motto,
+      image_url: self.image_url
+    }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :user_teams
+  has_many :user_teams, dependent: :destroy
   has_many :teams, through: :user_teams
   has_many :completions
   # has_many :workout_packs, through: :completions

--- a/app/models/user_team.rb
+++ b/app/models/user_team.rb
@@ -1,4 +1,4 @@
 class UserTeam < ApplicationRecord
-  belongs_to :user, dependent: :destroy
-  belongs_to :team, dependent: :destroy
+  belongs_to :user
+  belongs_to :team
 end

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,7 +1,7 @@
 class Workout < ApplicationRecord
-  has_many :workout_packs
+  has_many :workout_packs, dependent: :destroy
   has_many :packs, through: :workout_packs
   # has_many :completions #fake
-  has_many :workout_exercises
+  has_many :workout_exercises, dependent: :destroy
   has_many :exercises, through: :workout_exercises
 end

--- a/app/models/workout_exercise.rb
+++ b/app/models/workout_exercise.rb
@@ -1,5 +1,5 @@
 class WorkoutExercise < ApplicationRecord
-  belongs_to :exercise, dependent: :destroy
-  belongs_to :workout, dependent: :destroy
+  belongs_to :exercise
+  belongs_to :workout
 
 end

--- a/app/models/workout_pack.rb
+++ b/app/models/workout_pack.rb
@@ -1,5 +1,4 @@
 class WorkoutPack < ApplicationRecord
-  belongs_to :pack, dependent: :destroy
-  belongs_to :workout, dependent: :destroy
-  # has_many :completions #if we want it
+  belongs_to :pack
+  belongs_to :workout
 end

--- a/app/serializers/team_serializer.rb
+++ b/app/serializers/team_serializer.rb
@@ -1,0 +1,8 @@
+class TeamSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name, :motto, :image_url, :league
+  # 
+  # attribute :completions do |user|
+  #   user.completions.map {|completion| completion.format_json }
+  # end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -6,4 +6,12 @@ class UserSerializer
   attribute :completions do |user|
     user.completions.map {|completion| completion.format_json }
   end
+
+  attribute :teams do |user|
+    user.teams.map {|team| team.format_json }
+  end
+
+  # attribute :points_scored
+
+
 end


### PR DESCRIPTION
closes #11 
Dependent destroys were on the wrong side of the relationships. Moved them to the has_many side to eliminate the joins when an instance gets deleted